### PR TITLE
fix(apiGuide): make clearer the way to find partner id

### DIFF
--- a/pages/partners.js
+++ b/pages/partners.js
@@ -291,6 +291,9 @@ const Partners = () => (
     <SyntaxHighlighter language="bash" style={docco}>
       {CURL_SENCROP_PARTNER_USER_RETRIEVAL}
     </SyntaxHighlighter>
+    <p>
+      Then your <code>{"<PARTNER_ID>"}</code> will be in the <code>organisationId</code> field.
+    </p>
     <h2>
       <Anchor text="Delegation flows" />
     </h2>


### PR DESCRIPTION
fix: #24
